### PR TITLE
[WIP] Feedback always welcome!  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/

--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
+![recorder-image](https://user-images.githubusercontent.com/3109377/35347322-bab22268-012c-11e8-80d8-ef29d637fed7.jpeg)
+
 # scoop
 
-A Clojure library designed to ... well, that part is up to you.
+/skuːp/ informal
+
+*a piece of news published by a newspaper or broadcast by a television or radio station in advance of its rivals.*
+
+The original goal of this project was to talk to *Apache Kafka* directly, without any middleman (e.g. client/admin API) and take advantage of the Clojure REPL as a conversational interface. Removing the API from the equation means  that we can speak Kafka's mother tongue (Kafka protocol) without the API censoring us (e.g. validating what we send or restricting which information we get). In a nutshell, to make an interview to Kafka from the REPL. 
+
+An evolution over this idea is to use *clojure.spec* to describe Kafka's protocol requests and combine it with some generators from *clojure.test.check* to see how Kafka deals with malformed inputs at the protocol level. By adding some crash awareness this tool can easily become a Kafka protocol fuzzer.
 
 ## Usage
 
-FIXME
+Just spin up a REPL and use BOOTSTRAP_SERVERS environment var to point to a Kafka cluster. 
 
-## License
+```
+BOOTSTRAP_SERVERS="kafka:9092" lein repl
+```
 
-Copyright © 2018 FIXME
+![image](https://user-images.githubusercontent.com/3109377/35306289-d0b92158-0094-11e8-9a84-3edd99e8e3e3.png)
+## Resources
 
-Distributed under the Eclipse Public License either version 1.0 or (at
-your option) any later version.
+This tool was part of the presentation [Conversations with Kafka](https://github.com/nachomdo/scoop/files/1661729/Conversation.with.Kafka.pdf) for the [London Clojurians group](https://www.meetup.com/London-Clojurians/)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # scoop
-Speaking Kafka's protocol from Clojure REPL
+
+A Clojure library designed to ... well, that part is up to you.
+
+## Usage
+
+FIXME
+
+## License
+
+Copyright © 2018 FIXME
+
+Distributed under the Eclipse Public License either version 1.0 or (at
+your option) any later version.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+version: "2"
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:3.3.0
+    ports:
+      - "2181:2181"
+    environment:
+      zk_id: "1"
+      ZOOKEEPER_CLIENT_PORT: 2181
+
+  kafka:
+    image: confluentinc/cp-kafka:3.3.0
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_DELETE_TOPIC_ENABLE: "true"
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092"
+
+  kafka2:
+    image: confluentinc/cp-kafka:3.3.0
+    depends_on:
+      - zookeeper
+    ports:
+      - "9093:9093"
+    environment:
+      KAFKA_BROKER_ID: 2
+      KAFKA_DELETE_TOPIC_ENABLE: "true"
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka2:9093"
+
+  kafka3:
+    image: confluentinc/cp-kafka:3.3.0
+    depends_on:
+      - zookeeper
+    ports:
+      - "9094:9094"
+    environment:
+      KAFKA_BROKER_ID: 3
+      KAFKA_DELETE_TOPIC_ENABLE: "true"
+      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka3:9094"
+

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,8 @@
 (defproject scoop "0.1.0-SNAPSHOT"
-  :description "FIXME: write description"
+  :description "A tool to interview Apache Kafka by using the REPL"
   :url "http://example.com/FIXME"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]])
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.clojure/spec.alpha "0.1.143"]
+                 [org.clojure/test.check "0.9.0"]
+                 [t6/from-scala "0.3.0"]
+                 [org.apache.kafka/kafka_2.11 "1.0.0"]])

--- a/project.clj
+++ b/project.clj
@@ -1,0 +1,6 @@
+(defproject scoop "0.1.0-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/src/scoop/core.clj
+++ b/src/scoop/core.clj
@@ -1,6 +1,78 @@
-(ns scoop.core)
+(ns scoop.core
+  (:require [scoop.protocol :as sp]))
 
-(defn foo
-  "I don't do a whole lot."
-  [x]
-  (println x "Hello, World!"))
+;; Whats your name?
+
+(-> {:version       3
+     :request-type :metadata
+     ;; nil value for topics means all topics
+     :topics       nil}
+    sp/send-request
+    :cluster_id,)
+
+;; Tell me more about your cluster members...
+
+(-> {:version       3
+     :request-type :metadata
+     ;; nil value for topics means all topics
+     :topics       nil}
+    sp/send-request
+    :brokers)
+
+;; Which API version are you using?
+
+(-> {:version       1
+     :request-type :api-versions}
+    sp/send-request
+    :api_versions)
+
+
+;; Who is the cluster controller?
+
+(-> {:version       3
+     :request-type :metadata
+     ;; nil value for topics means all topics
+     :topics       nil}
+    sp/send-request
+    :controller_id)
+
+
+;; Who is the leader of a given partition and where are the replicas?
+
+(-> {:version       3
+     :request-type :metadata
+     :topics        ["dogs"]}
+    sp/send-request
+    :topic_metadata)
+
+;; Who is the coordinator of a given consumer group
+
+(-> {:version      0
+     :request-type :find-coordinator
+     :group-id     "test19"}
+    sp/send-request
+    :coordinator)
+
+;; Which topics have compaction as a clean.policy?
+
+;; Which applications are using a given topic?
+
+;; How many messages we have in a given topic?
+
+
+;; What is the lag and current offset of a given consumer group?
+(-> {:version      0
+     :request-type :offset-fetch
+     :group-id     "test"
+     :topics       [{:topic "dogs" :partitions [{:partition 1}]}]}
+    sp/send-request
+    :responses)
+
+;; this needs to be sent to the coordinator
+(-> {:version      1
+     :request-type :describe-groups
+     :group-ids    ["test19"]}
+    sp/send-request)
+
+;; Do you have any topic without leader?
+

--- a/src/scoop/core.clj
+++ b/src/scoop/core.clj
@@ -1,0 +1,6 @@
+(ns scoop.core)
+
+(defn foo
+  "I don't do a whole lot."
+  [x]
+  (println x "Hello, World!"))

--- a/src/scoop/protocol.clj
+++ b/src/scoop/protocol.clj
@@ -1,0 +1,312 @@
+(ns scoop.protocol
+  (:require [clojure.spec.alpha :as s]
+            [scoop.spec :as ss]
+            [scoop.utils :as su])
+  (:import java.lang.reflect.Modifier
+           java.nio.ByteBuffer
+           org.apache.kafka.common.Node
+           org.apache.kafka.common.protocol.ApiKeys
+           [org.apache.kafka.common.protocol.types ArrayOf BoundField Field Schema Struct Type Type$1 Type$10 Type$11 Type$12 Type$13 Type$2 Type$3 Type$4 Type$5 Type$6 Type$7 Type$8 Type$9]
+           [org.apache.kafka.common.requests AbstractRequest AbstractRequest$Builder AbstractResponse]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; AbstractResponse translation into Clojure maps
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(declare struct->map map->struct)
+
+(def ^:dynamic *version* (short 0))
+
+(def types
+  (clojure.set/map-invert {:boolean         Type$1
+                           :int8            Type$2
+                           :int16           Type$3
+                           :int32           Type$4
+                           :unsigned-int32  Type$5
+                           :int64           Type$6
+                           :string          Type$7
+                           :nullable-string Type$8
+                           :bytes           Type$9
+                           :nullable-bytes  Type$10
+                           :records         Type$11
+                           :varint          Type$12
+                           :varlong         Type$13
+                           :array-of        ArrayOf
+                           :schema          Schema}))
+
+(defmulti unmarshall-field
+  "Converts a field from its Kafka Type to Clojure"
+  (fn [^BoundField f _]
+    (let [field-type (.. f def type getClass)]
+      (get types field-type :type-not-found))))
+
+(defmethod unmarshall-field :boolean
+  [^BoundField f ^Struct item]
+  (.getBoolean item f))
+
+(defmethod unmarshall-field :int8
+  [^BoundField f ^Struct item]
+  (.getByte item f))
+
+(defmethod unmarshall-field :int16
+  [^BoundField f ^Struct item]
+  (.getShort item f))
+
+(defmethod unmarshall-field :int32
+  [^BoundField f ^Struct item]
+  (.getInt item f))
+
+(defmethod unmarshall-field :unsigned-int32
+  [^BoundField f ^Struct item]
+  (.getLong item f))
+
+(defmethod unmarshall-field :int64
+  [^BoundField f ^Struct item]
+  (.getLong item f))
+
+(defmethod unmarshall-field :string
+  [^BoundField f ^Struct item]
+  (.getString item f))
+
+(defmethod unmarshall-field :nullable-string
+  [^BoundField f ^Struct item]
+  (.getString item f))
+
+(defmethod unmarshall-field :bytes
+  [^BoundField f ^Struct item]
+  (.getBytes item f))
+
+(defmethod unmarshall-field :nullable-bytes
+  [^BoundField f ^Struct item]
+  (.getBytes item f))
+
+(defmethod unmarshall-field :records
+  [^BoundField f ^Struct item]
+  (.getRecords item f))
+
+(defmethod unmarshall-field :varint
+  [^BoundField f ^Struct item]
+  (.getInt item f))
+
+(defmethod unmarshall-field :varlong
+  [^BoundField f ^Struct item]
+  (.getLong item f))
+
+(def simple-type?
+  (let [simple-types (->> (.getDeclaredFields Type)
+                          (filter #(Modifier/isStatic (.getModifiers %)))
+                          (mapv #(format "ARRAY(%s)" (.getName %))))]
+    (fn [^BoundField f]
+      (some #{(.. f def type toString)} simple-types))))
+
+
+(defmethod unmarshall-field :array-of
+  [^BoundField field ^Struct item]
+  (let [xs (.getArray item field)]
+    (if (simple-type? field)
+      (mapv identity xs)
+      (mapv struct->map xs))))
+
+(defn field-name
+  "Extracts the field name"
+  [^BoundField field]
+  (.. field def name))
+
+
+(defmethod unmarshall-field :schema
+  [^BoundField f ^Struct item]
+  (struct->map (.getStruct item (field-name f))))
+
+
+(defn response->struct
+  "Converts any AbstractResponse instance a Struct"
+  [^AbstractResponse response]
+  (.invoke (su/expose-private-method (class response) "toStruct")
+           response
+           (into-array Object [*version*])))
+
+(defn struct->map
+  "Converts any Struct instance into a Clojure map"
+  [^Struct response]
+  (let [fields (.. response schema fields)]
+    (->> fields
+         (reduce (fn [m field]
+                   (assoc m
+                          (field-name field)
+                          (unmarshall-field field response)))
+                 {})
+         clojure.walk/keywordize-keys)))
+
+(def response->map (comp struct->map response->struct))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Building AbstractRequest from Clojure maps
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn request-type->class
+  [x]
+  (->> x
+       name
+       su/pascal-case
+       (format "org.apache.kafka.common.requests.%sRequest")
+       symbol
+       resolve))
+
+(defn request-type-constructor
+  "Finds the Struct based common constructor for
+  a given request type"
+  [x]
+  (let [constructors (->> x
+                         request-type->class
+                         .getDeclaredConstructors
+                         (into []))
+        common-constructor? (fn [c]
+                              (when (= (first (into [] (.getParameterTypes c)))
+                                       org.apache.kafka.common.protocol.types.Struct)
+                                c))]
+    (some common-constructor? constructors)))
+
+;; There is a better way using ApiKeys/schemaFor 
+(defn request-type-schemas
+  [x]
+  (into [] (.invoke (.getDeclaredMethod (request-type->class x) "schemaVersions" nil) nil nil)))
+
+(defn trace
+  [x]
+  (prn "trace " x)
+  x)
+
+(defn field-name->keyword
+  [x]
+  (keyword (clojure.string/replace x #"_" "-")))
+
+(defn marshall-value
+  [v]
+  (cond
+    (map? v) (map->struct v)
+    (vector? v) (into-array Object (mapv marshall-value v))
+    :else v))
+
+(defn ^:private type-for-value
+  [v]
+  (cond (vector? v) (ArrayOf. (type-for-value (first v)))
+        (string? v) Type/STRING
+        (integer? v) Type/INT32
+        (boolean? v) Type/BOOLEAN
+        ;; Oversimplification. This could be a byte array as well 
+        (nil? v) Type/NULLABLE_STRING 
+        (bytes? v) Type/BYTES))
+
+(defn keyword->field-name
+  [k]
+  (-> (name k)
+      (clojure.string/replace #"-" "_")))
+
+(defn map-entry->field
+  [[k v]]
+  (Field. (keyword->field-name k) (type-for-value v)))
+
+(defn map->schema
+  [m]
+  (let [fields (mapv map-entry->field m)]
+    (Schema. (into-array Field fields))))
+
+(defn coerce
+  [{:keys [version request-type] :as m}]
+  (let [spec-name (format "%s-request-v%d" (name request-type) version)]
+    (s/conform (keyword "scoop.spec" spec-name) m)))
+
+(defn map->struct
+  [{:keys [version request-type] :as m}]
+  (let [schema (if request-type
+                 (-> request-type request-type-schemas (nth version))
+                 (map->schema m))
+        fields (mapv field-name (.fields schema))
+        unqualified-m (-> m
+                          clojure.walk/stringify-keys
+                          clojure.walk/keywordize-keys)]
+    (reduce
+     (fn [s v]
+       (doto s
+         (.set v (marshall-value ((field-name->keyword v) unqualified-m)))))
+     (Struct. schema)
+     fields)))
+
+(defn map->request
+  [{:keys [version request-type] :as m}]
+  {:pre [(s/valid? ::ss/valid-request m)]}
+  (let [ctr (request-type-constructor request-type)
+        args [(map->struct (coerce m)) (short version)]]
+    (.newInstance ctr (into-array Object args))))
+
+(defn ^:private proxy-request-builder
+  "ConsumerNetworkClient's send method expects an AbstractRequest.Builder
+  but this class doesn't have a common constructor like AbstractRequest subclasses
+  This function wraps our request type in an instance of AbstractRequest.Builder"
+  [^AbstractRequest request ^ApiKeys api-key]
+  (proxy [AbstractRequest$Builder] [api-key]
+    (build
+      ([this] request)
+      ([this short] request))))
+
+(defn ^:private request-type->api-key
+  [request-type]
+  (let [api-key (-> request-type keyword->field-name clojure.string/upper-case)
+        field (su/expose-private-field ApiKeys api-key)]
+    (.get field ApiKeys)))
+
+(defn ^:private send-request*
+  [{:keys [request-type version] :as m} send-fn]
+  (binding [*version* (short version)]
+    (-> m
+        map->request
+        (proxy-request-builder (request-type->api-key request-type))
+        send-fn
+        response->map)))
+
+(defn send-request
+  ([{:keys [request-type version] :as m}]
+   {:pre [(s/valid? ::ss/valid-request m)]}
+   (send-request* m su/send-any-node))
+  ([{:keys [request-type version] :as m} ^Node node]
+   {:pre [(s/valid? ::ss/valid-request m)]}
+   (send-request* m #(su/send-to % node))))
+
+(comment
+  ;; Some examples that use the code above
+
+  (send-request {:version 1 :request-type :api-versions})
+
+  (send-request {:version 2  :request-type :metadata :topics nil})
+
+  (defn kafka-node
+    [id host port]
+    (Node. id host port))
+
+  (defn find-coordinator-for
+    [group-id]
+    (send-request {:version 1
+                   :request-type :find-coordinator
+                   :coordinator-type (byte 0)
+                   :coordinator-key group-id}))
+
+  ;; We can create a consumer with an specific group id with the command below:
+  ;; kafka-console-consumer --consumer-property group.id=test19 --bootstrap-server localhost:9092 --topic my-topic --from-beginning
+  (defn kill-consumer-group
+    "Kills a client that belongs to the consumer group associated to the id"
+    [group-id]
+    (let [{:keys [node_id host port]} (:coordinator (find-coordinator-for group-id))]
+      (send-request {:version 0
+                     :request-type :join-group
+                     :group-id group-id
+                     :session-timeout 99999
+                     :member-id ""
+                     :protocol-type "consumer"
+                     :group-protocols [{:protocol-name "range"
+                                        :protocol-metadata (ByteBuffer/wrap (.getBytes ""))}
+                                       {:protocol-name "roundrobin"
+                                        :protocol-metadata (ByteBuffer/wrap (.getBytes ""))}]}
+                    (kafka-node node_id host port))))
+
+  (kill-consumer-group "my-group")
+
+  )

--- a/src/scoop/spec.clj
+++ b/src/scoop/spec.clj
@@ -1,0 +1,178 @@
+(ns scoop.spec
+  (:require [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen]))
+
+;; Conformers to coerce numerical values to the proper type
+
+(def int8 (s/conformer #(if (and (int? %) (< % 256))
+                          (byte %)
+                          ::s/invalid)))
+
+(def int16 (s/with-gen (s/conformer #(if (and (int? %) (< % 32,768))
+                            (short %)
+                            ::s/invalid))
+             #(gen/int)))
+
+(def int32 (s/with-gen (s/conformer #(if (and (int? %) (<= % Integer/MAX_VALUE))
+                            (int %)
+                            ::s/invalid))
+             #(gen/int)))
+
+
+(s/def ::request-type
+  #{:produce :fetch :list-offsets :metadata
+    :offset-commit :find-coordinator :join-group :offset-fetch
+    :heartbeat :leave-group :sync-group :stop-replica
+    :controlled-shutdown :update-metadata :leader-and-isr
+    :describe-groups :list-groups :api-versions :create-topics
+    :delete-topics :delete-records :init-producer-id :offset-for-leader-epoch
+    :add-partitions-to-txn :add-offsets-to-txn :end-txn :write-txn-markers
+    :txn-offset-commit :describe-acls :create-acls :delete-acls
+    :describe-configs :alter-configs :alter-replica-log-dirs :create-partitions})
+
+;; Common specs for AbstractRequest
+
+(s/def ::version (s/with-gen (s/conformer #(if (s/int-in-range? 0 6 %)
+                                  (short %)
+                                  ::s/invalid))
+                   #(gen/int)))
+
+(s/def ::request (s/keys :req-un [::version ::request-type]))
+
+;; ApiVersionsRequest specs
+
+(s/def ::api-versions-request-v0 (s/merge ::request))
+
+;; Same that v0 but Throttle time has been added to response
+(s/def ::api-versions-request-v1 (s/merge ::request))
+
+;; MetadataRequest specs
+
+(s/def ::topic string?)
+
+(s/def :metadata-request-v0/topics (s/coll-of ::topic))
+(s/def ::metadata-request-v0 (s/merge ::request (s/keys :req-un [:metadata-request-v0/topics])))
+
+(s/def :metadata-request-v1/topics (s/nilable :metadata-request-v0/topics))
+(s/def ::metadata-request-v1 (s/merge ::request (s/keys :req-un [:metadata-request-v1/topics])))
+
+;; Same that v1. An additional field for cluster id has been added to the v2 metadata response
+(s/def ::metadata-request-v2 (s/merge ::metadata-request-v1))
+;; Same that v1 and v2. An additional field for throttle time has been added to the v3 metadata response
+(s/def ::metadata-request-v3 (s/merge ::metadata-request-v2))
+
+(s/def ::allow-auto-topic-creation boolean?)
+(s/def ::metadata-request-v4 (s/merge ::metadata-request-v3 (s/keys :req-un [::allow-auto-topic-creation])))
+
+;; Same that v4. An additional field for offline_replicas has been added to the v5 metadata response
+(s/def ::metadata-request-v5 (s/merge ::metadata-request-v4))
+
+;; ListGroupsRequest specs
+
+(s/def ::list-groups-request-v0 (s/merge ::request))
+;; Same that v0 but Throttle time has been added to response
+(s/def ::list-groups-request-v1 (s/merge ::list-groups-request-v0))
+
+;; DescribeGroupRequest specs
+(s/def ::group-id string?)
+(s/def ::group-ids (s/coll-of ::group-id))
+
+(s/def ::describe-groups-request-v0 (s/merge ::request (s/keys :req-un [::group-ids])))
+;; Same that v0 but Throttle time has been added to response
+(s/def ::describe-groups-request-v1 (s/merge ::describe-groups-request-v0))
+
+
+;; CreateTopicsRequest specs
+(s/def ::num-partitions int32)
+(s/def ::replication-factor int16)
+(s/def ::partition int32)
+(s/def ::replica int32)
+(s/def ::replicas (s/coll-of ::replica))
+(s/def ::partition-replica-assignment-entry (s/keys :req-un [::partition ::replicas]))
+(s/def ::replica-assignment (s/coll-of ::partition-replica-assignment-entry))
+(s/def ::config-name string?)
+(s/def ::config-value (s/nilable string?))
+(s/def ::config-entry (s/keys :req-un [::config-name ::config-value]))
+(s/def ::config-entries (s/coll-of ::config-entry))
+(s/def ::timeout int32)
+
+(s/def :create-topics-request-v0/topic (s/keys :req-un [::topic
+                                                        ::num-partitions
+                                                        ::replication-factor
+                                                        ::replica-assignment
+                                                        ::config-entries]))
+(s/def ::create-topic-requests (s/with-gen
+                                 (s/coll-of :create-topics-request-v0/topic)
+                                #(gen/not-empty (gen/vector (s/gen :create-topics-request-v0/topic))))) 
+
+(s/def ::create-topics-request-v0 (s/merge ::request (s/keys :req-un [::create-topic-requests
+                                                                      ::timeout])))
+
+(s/def ::validate-only boolean?)
+(s/def ::create-topics-request-v1 (s/merge ::request
+                                           (s/keys :req-un [::create-topic-requests
+                                                            ::timeout
+                                                            ::validate-only])))
+;; same as v1. Throttle time has been added to the response
+(s/def ::create-topics-request-v2 (s/spec ::create-topics-request-v1))
+
+;; OffsetFetchRequest specs
+(s/def ::partitions (s/coll-of (s/keys :req-un [::partition])))
+(s/def :offset-fetch-request-v0/topics (s/coll-of (s/keys :req-un [::topic ::partitions])))
+
+(s/def :offset-fetch-request-v2/topics (s/with-gen (s/nilable (s/coll-of (s/keys :req-un [::topic ::partitions])))
+                                         #(gen/not-empty (gen/vector (s/gen (s/keys :req-un [::topic ::partitions]))))))
+
+;; Reads offsets from ZK
+(s/def ::offset-fetch-request-v0 (s/merge ::request (s/keys :req-un [::group-id :offset-fetch-request-v0/topics])))
+;; Reads offsets from Kafka
+(s/def ::offset-fetch-request-v1 (s/merge ::offset-fetch-request-v0))
+(s/def ::offset-fetch-request-v2 (s/merge ::request (s/keys :req-un [::group-id :offset-fetch-request-v2/topics])))
+;; same as v2. Throttle time has been added to v3 response
+(s/def ::offset-fetch-request-v3 (s/merge ::offset-fetch-request-v2))
+
+;; JoinGroupRequest specs
+(s/def ::protocol-name #{"range" "roundrobin"})
+(s/def ::protocol-metadata (s/with-gen #(instance? Object %)
+                             #(gen/bytes)))
+
+(s/def ::join-group-request-protocol (s/keys :req-un [::protocol-name ::protocol-metadata]))
+(s/def ::session-timeout int32)
+(s/def ::member-id string?)
+(s/def ::protocol-type #{"consumer"})
+(s/def ::group-protocols (s/coll-of ::join-group-request-protocol))
+(s/def ::join-group-request-v0 (s/merge ::request (s/keys :req-un [::group-id
+                                                                   ::session-timeout
+                                                                   ::member-id
+                                                                   ::protocol-type
+                                                                   ::group-protocols])))
+
+(s/def ::rebalance-timeout int32)
+(s/def ::join-group-request-v1 (s/merge ::request (s/keys :req-un [::group-id
+                                                                   ::session-timeout
+                                                                   ::rebalance-timeout
+                                                                   ::member-id
+                                                                   ::protocol-type
+                                                                   ::group-protocols])))
+;; v2 request is the same as v1. Throttle time has been added to response 
+(s/def ::join-group-request-v2 (s/merge ::join-group-request-v1))
+
+;; FindCoordinatorRequest specs
+(s/def ::find-coordinator-request-v0 (s/merge ::request (s/keys :req-un [::group-id])))
+(s/def ::coordinator-key string?)
+;; 0 group coordinator, 1 transaction coordinator
+(s/def ::coordinator-type #{(byte 0) (byte 1)})
+
+(s/def ::find-coordinator-request-v1 (s/merge ::request (s/keys :req-un [::coordinator-type ::coordinator-key])))
+
+
+;; ¯\_(ツ)_/¯ it needs to be a multi-method due to s/multi-spec
+(defmulti fetch-spec 
+  "allows to choose a spec based on version and request-type"
+  (fn [x] :default))
+
+(defmethod fetch-spec :default
+  [{:keys [request-type version] :as x}]
+  (keyword (format "scoop.spec/%s-request-v%d" (name request-type) version)))
+
+(s/def ::valid-request (s/multi-spec fetch-spec :valid-request))

--- a/src/scoop/utils.clj
+++ b/src/scoop/utils.clj
@@ -1,0 +1,55 @@
+(ns scoop.utils
+  (:require [t6.from-scala.core :as $])
+  (:import java.nio.ByteBuffer
+           java.util.concurrent.TimeUnit
+           [kafka.admin AdminClient AdminUtils]
+           kafka.server.ConfigType
+           kafka.utils.ZkUtils
+           org.apache.kafka.common.Node
+           org.apache.kafka.common.protocol.ApiKeys
+           [org.apache.kafka.common.requests AbstractRequest AbstractRequest$Builder ApiVersionsRequest$Builder ControlledShutdownRequest$Builder JoinGroupRequest$Builder JoinGroupRequest$ProtocolMetadata LeaveGroupRequest$Builder ListGroupsRequest$Builder ListOffsetRequest$Builder MetadataRequest MetadataRequest$Builder]))
+
+(defn pascal-case
+  [s]
+  (->> (clojure.string/split s #"-")
+       (mapv clojure.string/capitalize)
+       clojure.string/join))
+
+(defn expose-private-method
+  [target-class target-method]
+  (let [methods (into [] (.getDeclaredMethods target-class))
+        method  (first (filter #(= (.getName %) target-method) methods))
+        _ (.setAccessible method true)]
+    method))
+
+(defn expose-private-field
+  [target-class target-field]
+  (let [field (.getDeclaredField target-class target-field)]
+    (doto field
+      (.setAccessible true))))
+
+
+(def ^:private admin-client
+  (AdminClient/createSimplePlaintext (or (System/getenv "BOOTSTRAP_SERVERS") "localhost:9092")))
+
+;; TODO: Connection needs to be cleaned up if something goes wrong
+(def ^:private network-client
+  (.get (expose-private-field AdminClient "client") admin-client))
+
+(defn send-to
+  "Sends a request to an specific Kafka broker"
+  [^AbstractRequest$Builder request ^Node node]
+  (let [f (.send network-client node request)
+        _ (.awaitDone f Long/MAX_VALUE TimeUnit/MILLISECONDS)]
+    ;; TODO: This needs proper exception handling 
+    (if (.succeeded f)
+      (.. f value responseBody)
+      (throw (.exception f)))))
+
+(defn send-any-node
+  "Sends a request to any Kafka broker"
+  [^AbstractRequest$Builder request]
+  (let [nodes ($/view (.findAllBrokers admin-client))
+        node (rand-nth nodes)]
+    (send-to request node)))
+

--- a/test/scoop/core_test.clj
+++ b/test/scoop/core_test.clj
@@ -1,0 +1,7 @@
+(ns scoop.core-test
+  (:require [clojure.test :refer :all]
+            [scoop.core :refer :all]))
+
+(deftest a-test
+  (testing "FIXME, I fail."
+    (is (= 0 1))))

--- a/test/scoop/protocol_test.clj
+++ b/test/scoop/protocol_test.clj
@@ -1,0 +1,44 @@
+(ns scoop.protocol-test
+  (:require [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen]
+            [clojure.test :refer :all]
+            [scoop.protocol :refer :all]
+            [clojure.test.check.clojure-test :as ct]
+            [clojure.test.check.properties :as prop]
+            [scoop.spec :as ss])
+  (:import [org.apache.kafka.common.requests AbstractRequest MetadataRequest]))
+ 
+(defn request-type-and-version
+  [x]
+  (->> x
+       name
+       (re-find #"([\w|\\-]+)-request-v(\d+)")
+       rest))
+
+(defn adjust-generator-for
+  [spec]
+  (let [[req-type version] (request-type-and-version spec)]
+    (gen/fmap #(assoc %
+                      :version (read-string version)
+                      :request-type (keyword req-type))
+              (s/gen spec))))
+
+(def gen-requests
+  (gen/vector
+   (gen/one-of (mapv adjust-generator-for [::ss/create-topics-request-v0 ::ss/create-topics-request-v1 ::ss/create-topics-request-v2
+                                           ::ss/metadata-request-v0 ::ss/metadata-request-v1 ::ss/metadata-request-v3 ::ss/metadata-request-v4
+                                           ::ss/metadata-request-v5 ::ss/list-groups-request-v0 ::ss/list-groups-request-v1
+                                           ::ss/offset-fetch-request-v0 ::ss/offset-fetch-request-v1 ::ss/offset-fetch-request-v2
+                                           ::ss/offset-fetch-request-v3 ::ss/api-versions-request-v0 ::ss/api-versions-request-v1
+                                           ::ss/find-coordinator-request-v0 ::ss/find-coordinator-request-v1
+                                           ::ss/join-group-request-v0 ::ss/join-group-request-v1 ::ss/join-group-request-v2]))))
+ 
+(ct/defspec map->request-test 25
+  (prop/for-all [xs (gen/not-empty gen-requests)]
+                (every? #(instance? AbstractRequest (map->request %)) xs)))
+
+(ct/defspec send-test 10
+  (prop/for-all [xs (gen/not-empty gen-requests)]
+                (doseq [x xs]
+                  (send-request x))
+                true))

--- a/test/scoop/spec_test.clj
+++ b/test/scoop/spec_test.clj
@@ -1,0 +1,30 @@
+(ns scoop.spec-test
+  (:require [scoop.spec :refer :all]
+            [clojure.spec.alpha :as s]
+            [clojure.test :refer :all]))
+
+(def valid-create-topics-request {:version              0
+                                  :request-type         :create-topics
+                                  :timeout              40
+                                  :create-topic-requests [{:topic              "test"
+                                                           :num-partitions     1
+                                                           :replication-factor 3
+                                                           :replica-assignment []
+                                                           :config-entries     []}]})
+(def valid-api-versions-request {:version 1 :request-type :api-versions})
+
+(def invalid-create-topics-request (assoc valid-create-topics-request :version 1))
+
+(def non-existent-api-versions-request {:version 13 :request-type :api-versions})
+
+(def non-existent-request-type {:version 1 :request-type :rogue-request})
+
+(deftest validate-request-type-test
+  (testing "valid request types are properly validated with the correct spec"
+    (is (s/valid? :scoop.spec/valid-request valid-create-topics-request))
+    (is (s/valid? :scoop.spec/valid-request valid-api-versions-request))
+    (is (false? (s/valid? :scoop.spec/valid-request invalid-create-topics-request))))
+
+  (testing "throws an exception if the spec for a request does not exist"
+    (is (thrown? Exception (s/valid? :scoop.spec/valid-request non-existent-api-versions-request)))
+    (is (thrown? Exception (s/valid? :scoop.spec/valid-request non-existent-request-type)))))


### PR DESCRIPTION
The aim of this PR is to provide the following functionality:

    - send plain Clojure maps as Kafka request 
    - translate Kafka's response to a Clojure map
    - leverage clojure.spec to validate and generate request types

The design is based on taking advantage of the `toStruct` protected method for translating responses into maps and the common Struct based constructor present in all the AbstractRequest subclasses to translate maps into requests. 

Check the class hierarchy below: 
![kafka protocol uml - page 1](https://user-images.githubusercontent.com/3109377/35298684-dab489f0-007a-11e8-92b8-84183a8c2a62.png)
